### PR TITLE
include disabling the footswitch whilst this feature runs

### DIFF
--- a/bin/vim-clutchify
+++ b/bin/vim-clutchify
@@ -7,26 +7,38 @@ from evdev import UInput, InputEvent, ecodes as e
 import re
 from time import sleep
 
-def tap(ui, key):
-    key = getattr(e, "KEY_%s" % key.upper())
-    ui.write(e.EV_KEY, key, 1)
-    ui.write(e.EV_KEY, key, 0)
-    ui.syn()
+class DeviceContext():
+    def __init__(self, deviceName):
+        devices = [evdev.InputDevice(fn) for fn in evdev.list_devices()]
+        self.device = next(x for x in devices if re.search(deviceName, x.name))
+
+    def __enter__(self):
+        operate_xinput_device(MODE_DISABLE, self.device.name)
+        self.ui = UInput()
+        return self
+
+    def event_loop(self):
+        yield from self.device.read_loop()
+
+    def tap(self, key):
+        key = getattr(e, "KEY_%s" % key.upper())
+        self.ui.write(e.EV_KEY, key, 1)
+        self.ui.write(e.EV_KEY, key, 0)
+        self.ui.syn()
+
+    def __exit__(self, type, value, traceback):
+        self.ui.__exit__(type, value, traceback)
+        operate_xinput_device(MODE_ENABLE, self.device.name)
+
 
 def main():
-    devices = [evdev.InputDevice(fn) for fn in evdev.list_devices()]
-    device = next(x for x in devices if re.search("FootSwitch", x.name))
-    operate_xinput_device(MODE_DISABLE, device.name)
-    with UInput() as ui:
-        try:
-            for event in device.read_loop():
-                if event.type == evdev.ecodes.EV_KEY:
-                    if event.value == 1:
-                        tap(ui, "F11")
-                    elif event.value == 0:
-                        tap(ui, "F12")
-        finally:
-            operate_xinput_device(MODE_ENABLE, device.name)
+    with DeviceContext("FootSwitch") as device:
+        for event in device.event_loop():
+            if event.type == e.EV_KEY:
+                if event.value == 1:
+                    device.tap("F11")
+                elif event.value == 0:
+                    device.tap("F12")
 
 if __name__ == "__main__":
     main()

--- a/bin/vim-clutchify
+++ b/bin/vim-clutchify
@@ -22,11 +22,9 @@ def main():
             for event in device.read_loop():
                 if event.type == evdev.ecodes.EV_KEY:
                     if event.value == 1:
-                        tap(ui, "esc")
-                        sleep(0.01)
-                        tap(ui, "a")
+                        tap(ui, "F11")
                     elif event.value == 0:
-                        tap(ui, "esc")
+                        tap(ui, "F12")
         finally:
             operate_xinput_device(MODE_ENABLE, device.name)
 

--- a/bin/vim-clutchify
+++ b/bin/vim-clutchify
@@ -7,6 +7,12 @@ from evdev import UInput, InputEvent, ecodes as e
 import re
 from time import sleep
 
+def tap(ui, key):
+    key = getattr(e, "KEY_%s" % key.upper())
+    ui.write(e.EV_KEY, key, 1)
+    ui.write(e.EV_KEY, key, 0)
+    ui.syn()
+
 def main():
     devices = [evdev.InputDevice(fn) for fn in evdev.list_devices()]
     device = next(x for x in devices if re.search("FootSwitch", x.name))
@@ -16,17 +22,11 @@ def main():
             for event in device.read_loop():
                 if event.type == evdev.ecodes.EV_KEY:
                     if event.value == 1:
-                        ui.write(e.EV_KEY, e.KEY_ESC, 1)
-                        ui.write(e.EV_KEY, e.KEY_ESC, 0)
-                        ui.syn()
+                        tap(ui, "esc")
                         sleep(0.01)
-                        ui.write(e.EV_KEY, e.KEY_A, 1)
-                        ui.write(e.EV_KEY, e.KEY_A, 0)
-                        ui.syn()
+                        tap(ui, "a")
                     elif event.value == 0:
-                        ui.write(e.EV_KEY, e.KEY_ESC, 1)
-                        ui.write(e.EV_KEY, e.KEY_ESC, 0)
-                        ui.syn()
+                        tap(ui, "esc")
         finally:
             operate_xinput_device(MODE_ENABLE, device.name)
 

--- a/bin/vim-clutchify
+++ b/bin/vim-clutchify
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 import sys
+from xinput import operate_xinput_device, MODE_ENABLE, MODE_DISABLE
 import evdev
 from evdev import UInput, InputEvent, ecodes as e
 import re
@@ -9,21 +10,25 @@ from time import sleep
 def main():
     devices = [evdev.InputDevice(fn) for fn in evdev.list_devices()]
     device = next(x for x in devices if re.search("FootSwitch", x.name))
+    operate_xinput_device(MODE_DISABLE, device.name)
     with UInput() as ui:
-        for event in device.read_loop():
-            if event.type == evdev.ecodes.EV_KEY:
-                if event.value == 1:
-                    ui.write(e.EV_KEY, e.KEY_ESC, 1)
-                    ui.write(e.EV_KEY, e.KEY_ESC, 0)
-                    ui.syn()
-                    sleep(0.01)
-                    ui.write(e.EV_KEY, e.KEY_A, 1)
-                    ui.write(e.EV_KEY, e.KEY_A, 0)
-                    ui.syn()
-                elif event.value == 0:
-                    ui.write(e.EV_KEY, e.KEY_ESC, 1)
-                    ui.write(e.EV_KEY, e.KEY_ESC, 0)
-                    ui.syn()
+        try:
+            for event in device.read_loop():
+                if event.type == evdev.ecodes.EV_KEY:
+                    if event.value == 1:
+                        ui.write(e.EV_KEY, e.KEY_ESC, 1)
+                        ui.write(e.EV_KEY, e.KEY_ESC, 0)
+                        ui.syn()
+                        sleep(0.01)
+                        ui.write(e.EV_KEY, e.KEY_A, 1)
+                        ui.write(e.EV_KEY, e.KEY_A, 0)
+                        ui.syn()
+                    elif event.value == 0:
+                        ui.write(e.EV_KEY, e.KEY_ESC, 1)
+                        ui.write(e.EV_KEY, e.KEY_ESC, 0)
+                        ui.syn()
+        finally:
+            operate_xinput_device(MODE_ENABLE, device.name)
 
 if __name__ == "__main__":
     main()

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,6 @@ See https://github.com/alevchuk/vim-clutch
 
         keywords='vim evdev footpedal footswitch vim-clutch clutch',
         packages=find_packages(),
-        install_requires=['evdev'],
+        install_requires=['evdev', 'xinput'],
         scripts=['bin/vim-clutchify']
 )

--- a/vim-clutchify.service
+++ b/vim-clutchify.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Vim Clutch Service
+After=graphical.target
+
+[Service]
+ExecStart=vim-clutchify
+Restart=always
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
This PR updates the script to automatically disable the footswitch via xinput and re-enable it if the script is terminated
It uses the device-name from the evdev search for the device to listen to and a try/finally to restore the default behaviour when turned off